### PR TITLE
Git tip was added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # devTips
 Developer Tips (PHP, MySQL, JavaScript, HTML, CSS, Git etc.)
+
+### Tips topic reference (in alphabetical order)
+- [git](./git/README.md)
+- [HTML](./html/)
+- [JavaScript](./js/)
+- [MySQL](./mysql/)
+- [PHP](./php/)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# devTips
+Developer Tips (PHP, MySQL, JavaScript, HTML, CSS, Git etc.)

--- a/git/README.md
+++ b/git/README.md
@@ -3,6 +3,7 @@
 - [Git global user setup](#git-global-user-setup)
 - [Create a new repository](#create-a-new-repository)
 - [Init repository in existing folder](#init-repository-in-existing-folder)
+- [Bind remote repository with local one](#bind-remote-repository-with-local-one)
 - [Switch existing Git repository](#switch-existing-git-repository)
 - [Store credentials](#store-credentials)
 - [Revert commit](#revert-commit)
@@ -33,6 +34,15 @@ git commit -m "Initial commit"
 git push -u origin master
 ```
 
+### Bind remote repository with local one
+```
+git add .
+git commit -m "Initial commit"
+git remote add origin https://github.com/dzarezenko/devTips.git
+git pull origin master --allow-unrelated-histories
+git push
+```
+
 ### Switch existing Git repository
 ```
 cd existing_repo
@@ -44,13 +54,13 @@ git push -u origin --tags
 
 ### Store credentials
 
-For temporary store credentials in memory use: 
+For temporary store credentials in memory use:
 
 ```
 git config --global credential.helper cache
 ```
 
-For permanent store use: 
+For permanent store use:
 
 ```
 git config --global credential.helper store

--- a/git/README.md
+++ b/git/README.md
@@ -40,7 +40,7 @@ git add .
 git commit -m "Initial commit"
 git remote add origin https://github.com/dzarezenko/devTips.git
 git pull origin master --allow-unrelated-histories
-git push
+git push -u origin master
 ```
 
 ### Switch existing Git repository


### PR DESCRIPTION
Proposed `git` tip is useful in case IDE created its own repository or repository-related files (such as `.gitignore`), but remote repository had been created beforehand. Therefore this tip allows to bind them and avoid deleting old remote repository and creating new empty one. 

Tips topic reference guide was added as well to newly created repository's general README.md.